### PR TITLE
Included adiw

### DIFF
--- a/avr-asm.JSON-tmLanguage
+++ b/avr-asm.JSON-tmLanguage
@@ -17,7 +17,7 @@
         },
 
         {
-            "match": "(?i)\\b(add|adc|sub|subi|sbc|sbci|sbiw|and|andi|or|ori|eor|com|neg|sbr|cbr|inc|dec|tst|clr|ser)\\b",
+            "match": "(?i)\\b(add|adc|adiw|sub|subi|sbc|sbci|sbiw|and|andi|or|ori|eor|com|neg|sbr|cbr|inc|dec|tst|clr|ser)\\b",
             "name": "keyword.operator.asm",
             "comment": "Arithmetic and logic instruction mnemonics"
         },


### PR DESCRIPTION
Add immediate word (adiw) was missing from the syntax highlighting. Also apparently GitHub threw a newline at the end as well.